### PR TITLE
fix: better representation of commit timestamps - don't default to now

### DIFF
--- a/src/metrics/commits_per_pr/__tests__/__snapshots__/commits-per-pr.test.ts.snap
+++ b/src/metrics/commits_per_pr/__tests__/__snapshots__/commits-per-pr.test.ts.snap
@@ -2083,10 +2083,22 @@ exports[`Commits Per PR handles a range of mocked pull_request events: pull_requ
     "output": {
       "additions": 1,
       "commit_timestamps": [
-        1675874104000,
-        1675877704000,
-        1675881304000,
-        1675884904000,
+        {
+          "authored": 1675874104000,
+          "committed": null,
+        },
+        {
+          "authored": null,
+          "committed": null,
+        },
+        {
+          "authored": 1675881304000,
+          "committed": 1675895704000,
+        },
+        {
+          "authored": 1675884904000,
+          "committed": 1675895764000,
+        },
       ],
       "commits": 4,
       "deletions": 1,
@@ -2640,10 +2652,22 @@ exports[`Commits Per PR handles a range of mocked pull_request events: pull_requ
     "output": {
       "additions": 1,
       "commit_timestamps": [
-        1675874104000,
-        1675877704000,
-        1675881304000,
-        1675884904000,
+        {
+          "authored": 1675874104000,
+          "committed": null,
+        },
+        {
+          "authored": null,
+          "committed": null,
+        },
+        {
+          "authored": 1675881304000,
+          "committed": 1675895704000,
+        },
+        {
+          "authored": 1675884904000,
+          "committed": 1675895764000,
+        },
       ],
       "commits": 4,
       "deletions": 1,
@@ -16056,10 +16080,22 @@ exports[`Commits Per PR handles a range of mocked pull_request events: pull_requ
     "output": {
       "additions": 1,
       "commit_timestamps": [
-        1675874104000,
-        1675877704000,
-        1675881304000,
-        1675884904000,
+        {
+          "authored": 1675874104000,
+          "committed": null,
+        },
+        {
+          "authored": null,
+          "committed": null,
+        },
+        {
+          "authored": 1675881304000,
+          "committed": 1675895704000,
+        },
+        {
+          "authored": 1675884904000,
+          "committed": 1675895764000,
+        },
       ],
       "commits": 4,
       "deletions": 1,
@@ -16632,10 +16668,22 @@ exports[`Commits Per PR handles a range of mocked pull_request events: pull_requ
     "output": {
       "additions": 1,
       "commit_timestamps": [
-        1675874104000,
-        1675877704000,
-        1675881304000,
-        1675884904000,
+        {
+          "authored": 1675874104000,
+          "committed": null,
+        },
+        {
+          "authored": null,
+          "committed": null,
+        },
+        {
+          "authored": 1675881304000,
+          "committed": 1675895704000,
+        },
+        {
+          "authored": 1675884904000,
+          "committed": 1675895764000,
+        },
       ],
       "commits": 4,
       "deletions": 1,

--- a/src/metrics/commits_per_pr/__tests__/commits-per-pr.test.ts
+++ b/src/metrics/commits_per_pr/__tests__/commits-per-pr.test.ts
@@ -17,16 +17,15 @@ const octokitResponse = {
       },
     },
     {
-      commit: {
-        author: {
-          date: "2023-02-08T17:35:04Z",
-        },
-      },
+      commit: {},
     },
     {
       commit: {
         author: {
           date: "2023-02-08T18:35:04Z",
+        },
+        committer: {
+          date: "2023-02-08T22:35:04Z",
         },
       },
     },
@@ -34,6 +33,9 @@ const octokitResponse = {
       commit: {
         author: {
           date: "2023-02-08T19:35:04Z",
+        },
+        committer: {
+          date: "2023-02-08T22:36:04Z",
         },
       },
     },
@@ -109,7 +111,22 @@ describe("Commits Per PR", () => {
           additions: 10,
           deletions: 5,
           commit_timestamps: [
-            1675874104000, 1675877704000, 1675881304000, 1675884904000,
+            {
+              authored: 1675874104000,
+              committed: null,
+            },
+            {
+              authored: null,
+              committed: null,
+            },
+            {
+              authored: 1675881304000,
+              committed: 1675895704000,
+            },
+            {
+              authored: 1675884904000,
+              committed: 1675895764000,
+            },
           ],
           pr_id: 42424242,
         },

--- a/src/metrics/commits_per_pr/index.ts
+++ b/src/metrics/commits_per_pr/index.ts
@@ -18,7 +18,7 @@ export const collectCommitsPerPrMetrics = async (
   const additions = payload.pull_request.additions;
   const deletions = payload.pull_request.deletions;
   let numberOfCommits = -1;
-  let commit_timestamps: any;
+  let commit_timestamps: CommitsPerPrOutput["commit_timestamps"] = [];
 
   try {
     const request = await octokit.request(
@@ -33,11 +33,17 @@ export const collectCommitsPerPrMetrics = async (
     const data = request.data;
     numberOfCommits = data.length;
 
-    commit_timestamps = data.map(
-      ({ commit }) => moment.utc(commit.author?.date).valueOf() || []
-    );
+    // Checking the author date will not reflect amendments
+    commit_timestamps = data.map(({ commit }) => ({
+      authored: commit.author?.date
+        ? moment.utc(commit.author.date).valueOf()
+        : null,
+      committed: commit.committer?.date
+        ? moment.utc(commit.committer.date).valueOf()
+        : null,
+    }));
   } catch (error) {
-    commit_timestamps = [];
+    // TODO: send error output
   }
 
   const output: CommitsPerPrOutput = {

--- a/src/metrics/commits_per_pr/interfaces.d.ts
+++ b/src/metrics/commits_per_pr/interfaces.d.ts
@@ -6,6 +6,12 @@ export interface CommitsPerPrOutput {
   commits: number;
   additions: number;
   deletions: number;
-  commit_timestamps: [];
+  commit_timestamps: {
+    /** Time commit was authored (UNIX ms) */
+    authored: number | null;
+
+    /** Time commit was committed (UNIX ms) */
+    committed: number | null;
+  }[];
   pr_id: number;
 }


### PR DESCRIPTION
Note: the previous code looks like it defaulted to [] (which would have lead to the bad type `Array<number | []>`), but moment just uses now as a date if the input is undefined.