### PR TITLE
refactor: use enum for error level

### DIFF
--- a/src/core/add-signature.ts
+++ b/src/core/add-signature.ts
@@ -1,7 +1,7 @@
 import { LogInfos, LogWarnings } from "../shared/log-messages";
 import { SignedTriggerEvent, RawEvent } from "../interfaces";
 import { identifyTriggerEventSignature } from "../trigger-signatures";
-import { ErrorForLogger } from "./error-logger";
+import { ErrorForLogger, ErrorLevel } from "./error-logger";
 import { logger } from "./logger";
 
 export async function addSignature(
@@ -13,7 +13,7 @@ export async function addSignature(
 
   if (signature === null) {
     throw new ErrorForLogger(
-      "skip",
+      ErrorLevel.Skip,
       LogWarnings.signingEventSignatureNotRecognized
     );
   }

--- a/src/core/collect-metrics.ts
+++ b/src/core/collect-metrics.ts
@@ -2,7 +2,7 @@ import cloneDeep from "lodash.clonedeep";
 import metricsConditions from "../metrics-conditions";
 import { LogSuccess, LogWarnings } from "../shared/log-messages";
 import { MetricData, SignedTriggerEvent } from "../interfaces";
-import { ErrorForLogger } from "./error-logger";
+import { ErrorForLogger, ErrorLevel } from "./error-logger";
 import { logger } from "./logger";
 
 export const collectMetrics = async (
@@ -22,7 +22,7 @@ export const collectMetrics = async (
 
   if (collectedMetrics.length === 0) {
     throw new ErrorForLogger(
-      "skip",
+      ErrorLevel.Skip,
       LogWarnings.collectMetricsSignatureNotRecognized
     );
   }

--- a/src/core/error-logger.ts
+++ b/src/core/error-logger.ts
@@ -6,7 +6,11 @@ import {
 } from "../shared/log-messages";
 import { logger } from "./logger";
 
-type ErrorLevel = "error" | "warn" | "skip";
+export enum ErrorLevel {
+  Error = "error",
+  Warn = "warn",
+  Skip = "skip",
+}
 
 export class ErrorForLogger extends Error {
   level: ErrorLevel;

--- a/src/core/store-data.ts
+++ b/src/core/store-data.ts
@@ -1,6 +1,6 @@
 import { MetricData } from "../interfaces";
 import { octokitForDataRepo } from "./octokit";
-import { ErrorForLogger } from "./error-logger";
+import { ErrorForLogger, ErrorLevel } from "./error-logger";
 import { LogErrors, LogInfos, LogWarnings } from "../shared/log-messages";
 import {
   getOptionalEnvVar,
@@ -14,7 +14,7 @@ export class StoreDataError extends ErrorForLogger {
 
   static noReadAccess(status: number): StoreDataError {
     return new StoreDataError(
-      "error",
+      ErrorLevel.Error,
       LogErrors.dataRepoNoReadAccess,
       status.toString()
     );
@@ -22,7 +22,7 @@ export class StoreDataError extends ErrorForLogger {
 
   static noWriteAccess(status: number): StoreDataError {
     return new StoreDataError(
-      "error",
+      ErrorLevel.Error,
       LogErrors.dataRepoNoWriteAccess,
       status.toString()
     );

--- a/src/metrics/check-suite/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/check-suite/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { isSignedAsCheckSuiteCompleted } from "../metrics-conditions";
 
@@ -30,7 +30,7 @@ describe("Check Suite metric condition: isSignedAsCheckSuiteCompleted", () => {
     };
 
     expect(() => isSignedAsCheckSuiteCompleted(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/code-review-involvement/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/code-review-involvement/__tests__/metrics-conditions.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../interfaces";
 import { isSignedAsPullRequestClosed } from "../metrics-conditions";
 import { getWebhookEventFixture } from "../../../__tests__/fixtures/github-webhook-events";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 
 describe("Code Review Involvement metric condition: isSignedAsPullRequestClosed", () => {
@@ -30,7 +30,7 @@ describe("Code Review Involvement metric condition: isSignedAsPullRequestClosed"
     };
 
     expect(() => isSignedAsPullRequestClosed(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/commits-per-pr/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/commits-per-pr/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { isSignedAsCommitsPerPr } from "../metrics-conditions";
 
@@ -30,7 +30,7 @@ describe("Commits Per PR metric condition: isSignedAsCommitsPerPr", () => {
     };
 
     expect(() => isSignedAsCommitsPerPr(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/deployments/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/deployments/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { isSignedAsDeployment } from "../metrics-conditions";
 
@@ -30,7 +30,7 @@ describe("Deployment metric condition: isSignedAsDeployment", () => {
     };
 
     expect(() => isSignedAsDeployment(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/documentation-updated/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/documentation-updated/__tests__/metrics-conditions.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../interfaces";
 import { isSignedAsPullRequestMerged } from "../metrics-conditions";
 import { getWebhookEventFixture } from "../../../__tests__/fixtures/github-webhook-events";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 
 describe("Documentation Updated metric condition: isSignedAsPullRequestMerged", () => {
@@ -30,7 +30,7 @@ describe("Documentation Updated metric condition: isSignedAsPullRequestMerged", 
     };
 
     expect(() => isSignedAsPullRequestMerged(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/release-versions/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/release-versions/__tests__/metrics-conditions.test.ts
@@ -6,7 +6,7 @@ import {
   GithubEvent,
 } from "../../../interfaces";
 import { isSignedAsTagCreateEvent } from "../metrics-conditions";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 
 describe("Release Versions metric condition: isSignedAsTagCreateEvent", () => {
@@ -34,7 +34,7 @@ describe("Release Versions metric condition: isSignedAsTagCreateEvent", () => {
     };
 
     expect(() => isSignedAsTagCreateEvent(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/test-coverage/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/test-coverage/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { isSignedAsWorkflowJobTestCoverage } from "../metrics-conditions";
 
@@ -30,7 +30,7 @@ describe("Test Coverage metric condition: isSignedAsWorkflowJobTestCoverage", ()
     };
 
     expect(() => isSignedAsWorkflowJobTestCoverage(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/tooling-usage/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/tooling-usage/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { ToolingUsagePayload } from "../interfaces";
 import { isSignedAsToolingUsage } from "../metrics-conditions";
@@ -31,7 +31,7 @@ describe("Tooling Usage metric condition: isSignedAsToolingUsage", () => {
     };
 
     expect(() => isSignedAsToolingUsage(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/metrics/workflows/__tests__/metrics-conditions.test.ts
+++ b/src/metrics/workflows/__tests__/metrics-conditions.test.ts
@@ -4,7 +4,7 @@ import {
   SignedTriggerEvent,
   GithubEvent,
 } from "../../../interfaces";
-import { ErrorForLogger } from "../../../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../../../core/error-logger";
 import { LogWarnings } from "../../../shared/log-messages";
 import { isSignedAsWorkflowJob } from "../metrics-conditions";
 
@@ -30,7 +30,7 @@ describe("Workflows metric condition: isSignedAsWorkflowJob", () => {
     };
 
     expect(() => isSignedAsWorkflowJob(event)).toThrow(
-      new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo)
+      new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo)
     );
   });
 

--- a/src/shared/abort-if-data-repo.ts
+++ b/src/shared/abort-if-data-repo.ts
@@ -1,4 +1,4 @@
-import { ErrorForLogger } from "../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../core/error-logger";
 import { getRequiredEnvVar } from "./get-env-var";
 import { LogWarnings } from "./log-messages";
 
@@ -7,6 +7,6 @@ export function abortIfDataRepo(fullRepoName) {
   const name = getRequiredEnvVar("REPO_NAME");
 
   if (fullRepoName === `${owner}/${name}`) {
-    throw new ErrorForLogger("skip", LogWarnings.repoIsDatabaseRepo);
+    throw new ErrorForLogger(ErrorLevel.Skip, LogWarnings.repoIsDatabaseRepo);
   }
 }

--- a/src/shared/get-env-var.ts
+++ b/src/shared/get-env-var.ts
@@ -1,4 +1,4 @@
-import { ErrorForLogger } from "../core/error-logger";
+import { ErrorForLogger, ErrorLevel } from "../core/error-logger";
 import { LogErrors } from "./log-messages";
 
 type KnownEnvironmentVariable =
@@ -20,15 +20,27 @@ export class EnvVarAccessError extends ErrorForLogger {
   name = "EnvVarAccessError";
 
   static required(name): EnvVarAccessError {
-    return new EnvVarAccessError("error", LogErrors.envVarRequired, name);
+    return new EnvVarAccessError(
+      ErrorLevel.Error,
+      LogErrors.envVarRequired,
+      name
+    );
   }
 
   static nan(name): EnvVarAccessError {
-    return new EnvVarAccessError("error", LogErrors.envVarNotANumber, name);
+    return new EnvVarAccessError(
+      ErrorLevel.Error,
+      LogErrors.envVarNotANumber,
+      name
+    );
   }
 
   static unsafeInt(name): EnvVarAccessError {
-    return new EnvVarAccessError("error", LogErrors.envVarUnsafeInt, name);
+    return new EnvVarAccessError(
+      ErrorLevel.Error,
+      LogErrors.envVarUnsafeInt,
+      name
+    );
   }
 }
 


### PR DESCRIPTION
Kept it simple for now with using enums instead of making a huge amount of code changes across the codebase.